### PR TITLE
Remove classical contexts

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -8,6 +8,10 @@ module IntMap = Map.Make (Int)
 let fst3 (a, _, _) = a
 let snd3 (_, b, _) = b
 let trd3 (_, _, c) = c
+let fst4 (a, _, _, _) = a
+let snd4 (_, b, _, _) = b
+let trd4 (_, _, c, _) = c
+let fth4 (_, _, _, d) = d
 
 let option_of_optionE (optE : 'a optionE) : 'a option =
   match optE with
@@ -108,7 +112,7 @@ let map_merge_noopt (allow_dup : bool) (d0 : 'a StringMap.t)
   | NoneE err -> failwith err
 
 (* Whether a map is included in another map *)
-let map_inclusion (d0 : 'a StringMap.t) (d1 : 'a StringMap.t) : bool =
+let map_is_inclusion (d0 : 'a StringMap.t) (d1 : 'a StringMap.t) : bool =
   StringMap.for_all (fun x t -> StringMap.find_opt x d1 = Some t) d0
 
 let map_dom (d : 'a StringMap.t) : StringSet.t =
@@ -118,10 +122,14 @@ let map_dom (d : 'a StringMap.t) : StringSet.t =
 let map_restriction (d : 'a StringMap.t) (s : StringSet.t) : 'a StringMap.t =
   StringMap.filter (fun x _ -> StringSet.mem x s) d
 
+(* Restrict map to include only variables from a given set *)
+let map_exclusion (d : 'a StringMap.t) (s : StringSet.t) : 'a StringMap.t =
+  StringMap.filter (fun x _ -> not (StringSet.mem x s)) d
+
 (* Partition map d into part belonging to s and part not belonging to s *)
 let map_partition (d : 'a StringMap.t) (s : StringSet.t) :
     'a StringMap.t * 'a StringMap.t =
-  (map_restriction d s, StringMap.filter (fun x _ -> not (StringSet.mem x s)) d)
+  (map_restriction d s, map_exclusion d s)
 
 let int_map_find_or_keep (m : int IntMap.t) (i : int) : int =
   match IntMap.find_opt i m with

--- a/test/test_compilation.ml
+++ b/test/test_compilation.ml
@@ -142,15 +142,13 @@ let () =
         "walk_1d.qunity";
       ]
     in
-    let _ =
-      Array.map
+      Array.iter
         begin
-          fun filename ->
+          fun (filename : string) ->
             if not (List.mem filename skipped_files) then
               test_compilation_correctness_file ("examples/" ^ filename)
         end
-        example_files
-    in
+        example_files;
       if !all_passed then
         Printf.printf "\nALL COMPILATION TESTS PASSED\n\n"
       else begin

--- a/test/test_semantics.ml
+++ b/test/test_semantics.ml
@@ -101,7 +101,7 @@ let () =
 
     expect_pure_prog_sem "qid_bit_sem" (qid bit) [[c1; c0]; [c0; c1]];
 
-    expect_pure_expr_sem "bell_sem"
+    expect_pure_expr_sem "half_bell_sem"
       (Ctrl
          ( Apply (had, bit0),
            bit,

--- a/test/test_typechecking.ml
+++ b/test/test_typechecking.ml
@@ -57,7 +57,7 @@ let expect_expr_puretype (testname : string) (e : expr) (t : exprtype) : unit =
   test_equality_optionE testname
     begin
       fun () ->
-        match pure_type_check StringMap.empty StringMap.empty e with
+        match pure_type_check StringMap.empty e with
         | SomeE tp -> SomeE (type_of_pure_expr_proof tp)
         | NoneE err -> NoneE err
     end
@@ -67,7 +67,7 @@ let expect_expr_puretype_err (testname : string) (e : expr) : unit =
   expect_noneE testname
     begin
       fun () ->
-        match pure_type_check StringMap.empty StringMap.empty e with
+        match pure_type_check StringMap.empty e with
         | SomeE tp -> SomeE (type_of_pure_expr_proof tp)
         | NoneE err -> NoneE err
     end
@@ -199,7 +199,7 @@ let () =
       (span_list (ProdType (bit, bit)) [Qpair (bit0, bit0)])
       (Some [Qpair (bit0, bit0); Qpair (bit0, bit1); Qpair (bit1, Var "$0")]);
 
-    expect_expr_puretype "bell_type"
+    expect_expr_puretype "half_bell_type"
       (Ctrl
          ( Apply (had, bit0),
            bit,


### PR DESCRIPTION
Removing classical contexts $\Gamma$ from the typing relations, and modifying the semantics and compilation of T-CTRL accordingly by explicitly partitioning the LHS contexts into a relevant and irrelevant part.